### PR TITLE
remove formatted string in export

### DIFF
--- a/zabbix-export.py
+++ b/zabbix-export.py
@@ -380,7 +380,7 @@ def main(zabbix_, save_yaml, directory):
                         aa['groupid'] = groupid2group[aa['groupid']]
                         del aa['operationid']
                         del aa['opcommand_grpid']
-                if f'opconditions' in op:
+                if 'opconditions' in op:
                     for aa in op['opconditions']:
                         del aa['operationid']
                         del aa['opconditionid']


### PR DESCRIPTION
remove formatted string cause it supported in python >= 3.6
not used f-string functional in this line

I tried using with python 3.5, and caught exception before changes.
Didn't see formatted string features usage.